### PR TITLE
fix: Add suffixes to generated directive and union names. Graphql sch…

### DIFF
--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -332,7 +332,7 @@ func (s *SchemaDescriptor) CreateObjects(d desc.Descriptor, input, useFieldNames
 				// create oneofs as directives for input objects
 				directive := &ast.DirectiveDefinition{
 					Description: getDescription(oneof),
-					Name:        s.uniqueName(oneof, input),
+					Name:        fmt.Sprintf("%sDirective", s.uniqueName(oneof, input)),
 					Locations:   []ast.DirectiveLocation{ast.LocationInputFieldDefinition},
 					Position:    &ast.Position{Src: &ast.Source{}},
 				}
@@ -739,7 +739,7 @@ func (s *SchemaDescriptor) createUnion(oneof *desc.OneOfDescriptor, useFieldName
 		Definition: &ast.Definition{
 			Kind:        ast.Union,
 			Description: getDescription(oneof),
-			Name:        s.uniqueName(oneof, false),
+			Name:        fmt.Sprintf("%sUnion", s.uniqueName(oneof, false)),
 			Types:       types,
 			Position:    &ast.Position{},
 		},

--- a/test/testdata/constructs-expect.graphql
+++ b/test/testdata/constructs-expect.graphql
@@ -1,7 +1,7 @@
 directive @Constructs on FIELD_DEFINITION
-directive @Oneof_Oneof1 on INPUT_FIELD_DEFINITION
-directive @Oneof_Oneof2 on INPUT_FIELD_DEFINITION
-directive @Oneof_Oneof3 on INPUT_FIELD_DEFINITION
+directive @Oneof_Oneof1Directive on INPUT_FIELD_DEFINITION
+directive @Oneof_Oneof2Directive on INPUT_FIELD_DEFINITION
+directive @Oneof_Oneof3Directive on INPUT_FIELD_DEFINITION
 """Any is any json type"""
 scalar Any
 enum Bar {
@@ -226,21 +226,21 @@ type Mutation {
 }
 type Oneof {
   param1: String
-  oneof1: Oneof_Oneof1
-  oneof2: Oneof_Oneof2
-  oneof3: Oneof_Oneof3
+  oneof1: Oneof_Oneof1Union
+  oneof2: Oneof_Oneof2Union
+  oneof3: Oneof_Oneof3Union
 }
 input OneofInput {
   param1: String
-  param2: String @Oneof_Oneof1
-  param3: String @Oneof_Oneof1
-  param4: String @Oneof_Oneof2
-  param5: String @Oneof_Oneof2
-  param6: String @Oneof_Oneof3
+  param2: String @Oneof_Oneof1Directive
+  param3: String @Oneof_Oneof1Directive
+  param4: String @Oneof_Oneof2Directive
+  param5: String @Oneof_Oneof2Directive
+  param6: String @Oneof_Oneof3Directive
 }
-union Oneof_Oneof1 = Oneof_Param2 | Oneof_Param3
-union Oneof_Oneof2 = Oneof_Param4 | Oneof_Param5
-union Oneof_Oneof3 = Oneof_Param6
+union Oneof_Oneof1Union = Oneof_Param2 | Oneof_Param3
+union Oneof_Oneof2Union = Oneof_Param4 | Oneof_Param5
+union Oneof_Oneof3Union = Oneof_Param6
 type Oneof_Param2 {
   param2: String
 }

--- a/test/testdata/options-expect.graphql
+++ b/test/testdata/options-expect.graphql
@@ -1,7 +1,7 @@
 directive @Query on FIELD_DEFINITION
 directive @Service on FIELD_DEFINITION
 directive @Test on FIELD_DEFINITION
-directive @ValueKind on INPUT_FIELD_DEFINITION
+directive @ValueKindDirective on INPUT_FIELD_DEFINITION
 directive @goField(forceResolver: Boolean, name: String) on INPUT_FIELD_DEFINITION | FIELD_DEFINITION
 type Data {
   stringX: String!
@@ -91,17 +91,17 @@ type Subscription {
   querySubscribe(in: DataInput): Data @Query
 }
 type Value {
-  kind: ValueKind
+  kind: ValueKindUnion
 }
 input ValueInput {
-  nullValue: NullValue @ValueKind
-  numberValue: Float @ValueKind
-  stringValue: String @ValueKind
-  boolValue: Boolean @ValueKind
-  structValue: StructInput @ValueKind
-  listValue: ListValueInput @ValueKind
+  nullValue: NullValue @ValueKindDirective
+  numberValue: Float @ValueKindDirective
+  stringValue: String @ValueKindDirective
+  boolValue: Boolean @ValueKindDirective
+  structValue: StructInput @ValueKindDirective
+  listValue: ListValueInput @ValueKindDirective
 }
-union ValueKind = Value_NullValue | Value_NumberValue | Value_StringValue | Value_BoolValue | Value_StructValue | Value_ListValue
+union ValueKindUnion = Value_NullValue | Value_NumberValue | Value_StringValue | Value_BoolValue | Value_StructValue | Value_ListValue
 type Value_BoolValue {
   boolValue: Boolean
 }


### PR DESCRIPTION
…ema validation fails if a union and directive have the same name.