### PR TITLE
fix: update app-utils-go version to avoid package name mismatch and include a few fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/99designs/gqlgen v0.17.16
-	github.com/catalystcommunity/app-utils-go v1.0.5
+	github.com/catalystcommunity/app-utils-go v1.0.9
 	github.com/golang/protobuf v1.5.2
 	github.com/jhump/protoreflect v1.12.0
 	github.com/nautilus/gateway v0.3.2


### PR DESCRIPTION
Fixes a name mismatch:

```
module declares its path as: github.com/catalystsquad/app-utils-go
	        but was required as: github.com/catalystcommunity/app-utils-go
```

Also includes a couple other fixes, which can be seen in the [app-utils-go `CHANGELOG.MD`](https://github.com/catalystcommunity/app-utils-go/blob/48730234af3e1b1fdb0ba852b77e8a95ff6b9d4b/CHANGELOG.md) (which I have pinned the link to the `1.0.9` release commit for posterity)